### PR TITLE
Use ogg123 instead of mplayer

### DIFF
--- a/naudio/plugin.py
+++ b/naudio/plugin.py
@@ -13,7 +13,7 @@ default_failure = "/".join([assets, "the-price-is-right-failure.ogg"])
 def play(filename):
     if not os.path.exists(filename):
         return
-    cmd = "mplayer " + filename
+    cmd = "ogg123 " + filename
     process = subprocess.Popen(
         [cmd],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
ogg123 is part of the vorbis-tools package and is more likely to be installed than mplayer, which is not in the Fedora repos. :musical_score: 
