### PR TITLE
Support Python 3.x

### DIFF
--- a/naudio/__init__.py
+++ b/naudio/__init__.py
@@ -1,1 +1,1 @@
-from plugin import NoseAudioPlugin
+from .plugin import NoseAudioPlugin

--- a/naudio/plugin.py
+++ b/naudio/plugin.py
@@ -59,12 +59,12 @@ class NoseAudioPlugin(Plugin):
 
     def finalize(self, result):
         if not (result.errors or result.failures):
-            print "-" * 70
-            print "Success!"
+            print("-" * 70)
+            print("Success!")
             outro = play(self.options.audio_success)
         else:
-            print "-" * 70
-            print "Uh-oh..."
+            print("-" * 70)
+            print("Uh-oh...")
             outro = play(self.options.audio_failure)
 
         if self.busy_process:


### PR DESCRIPTION
This PR patches nose-audio to support Python 3. It uses relative imports, which means that in turn it drops support for Pythons earlier than 2.6. I hope that's an acceptable tradeoff.
